### PR TITLE
Enable GA by setting HUGO_ENV to production when deploying

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -27,4 +27,4 @@ jobs:
     - name: Build Site
       run: |
         git config --global core.quotePath false
-        hugo --minify
+        HUGO_ENV=production hugo --minify

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Build Site
       run: |
         git config --global core.quotePath false
-        hugo --minify
+        HUGO_ENV=production hugo --minify
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3
       with:

--- a/config.toml
+++ b/config.toml
@@ -49,6 +49,10 @@ anchor = "smart"
 # Comment out the next line to disable GA tracking. Also disables the feature described in [params.ui.feedback].
 id = "UA-96337051-5"
 
+[privacy]
+[privacy.googleAnalytics]
+anonymizeIP = true
+
 # Language configuration
 
 [languages]


### PR DESCRIPTION
Before this commit GA doesn't work, this commit fixes it, and also enables privacy protection of GA (anonymize IP).