### PR TITLE
docs: fix Slack link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -166,6 +166,6 @@ enable = false
         desc = "Development takes place here!"
 [[params.links.developer]]
 	name = "Slack"
-	url = "https://join.slack.com/t/cpeditor/shared_invite/zt-dke1v9xd-zr~QeXJhCzbM9FFOjx6sMA"
+	url = "https://join.slack.com/t/cpeditor/shared_invite/zt-ekfy0zb5-SrOi8SIox8oq61oRonBynw"
 	icon = "fab fa-slack"
         desc = "Chat with other project developers"


### PR DESCRIPTION
The old link is expired, and the new link will never expire.