### PR TITLE
Fix a typo of "Source Code" in the documentation

### DIFF
--- a/content/en/docs/Source Code/_index.md
+++ b/content/en/docs/Source Code/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Source Code"
-linkTitle: "Srouce Code"
+linkTitle: "Source Code"
 weight: 60
 description: The structure and functionality of each part of the source code
 ---


### PR DESCRIPTION
This fixes #24.