### PR TITLE
fix: disable HTML minification

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -44,6 +44,9 @@ resampleFilter = "CatmullRom"
 quality = 75
 anchor = "smart"
 
+[minify]
+disableHTML = true
+
 [services]
 [services.googleAnalytics]
 # Comment out the next line to disable GA tracking. Also disables the feature described in [params.ui.feedback].


### PR DESCRIPTION
The HTML minification doesn't always work.

For example, after minification, the space after "Editor" in `<h2>The Missing Editor <br />for Competitive Programmers</h2>` is removed, the result is, on narrow screens, the "Editor" and "for" are connected without space.

![image](https://user-images.githubusercontent.com/30581822/86310437-acc1a980-bc50-11ea-8aec-bfc42a836e51.png)
