### PR TITLE
ci: don't check external links

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -29,6 +29,6 @@ jobs:
         id: check-links
         uses: peter-evans/link-checker@v1
         with:
-          args: -r public -d public
+          args: -r public -d public -x "https?:\/\/"
       - name: Fail on link errors
         run: exit ${{ steps.check-links.outputs.exit_code }}


### PR DESCRIPTION
Don't check external links, otherwise it fails when new pages are created in a PR which is not merged.