### PR TITLE
feat(Installation): add guidelines for the deb package

### DIFF
--- a/content/en/docs/Installation/Install from binaries/_index.md
+++ b/content/en/docs/Installation/Install from binaries/_index.md
@@ -30,6 +30,7 @@ On Debian-based Linux distributions (Ubuntu, Linux Mint and etc.) you can downlo
     ```sh
     sudo apt install ./<path to .deb package>
     ```
+
 Then type your root password and agree with the installation. You can also use `Gdebi` or another graphical tools to install `deb` package. Supported: Debian 10 Buster, Ubuntu 18.04 Bionic Beaver, Linux Mint 19 Tara and newer versions of these distributions or based on them.
 
 ### MacOS

--- a/content/en/docs/Installation/Install from binaries/_index.md
+++ b/content/en/docs/Installation/Install from binaries/_index.md
@@ -25,6 +25,12 @@ Download the `portable.zip` in the assets and unzip it to any directory you like
 
 Download the `AppImage` in the assets, add execute permission to it (`chmod +x <AppImagePath>`), then run it.
 
+On Debian-based Linux distributions (Ubuntu, Linux Mint and etc.) you can download `.deb` package in the assets and run the command in terminal:
+```sh
+sudo apt install ./<path to .deb package>
+```
+Then type your root password and agree with the installation. You can also use `Gdebi` or another graphical tools to install `deb` package. Supported: Debian 10 Buster, Ubuntu 18.04 Bionic Beaver, Linux Mint 19 Tara and newer versions of these distributions or based on them.
+
 ### MacOS
 
 Download the `.dmg` file in the assets and install it.

--- a/content/en/docs/Installation/Install from binaries/_index.md
+++ b/content/en/docs/Installation/Install from binaries/_index.md
@@ -28,7 +28,7 @@ Download the `AppImage` in the assets, add execute permission to it (`chmod +x <
 On Debian-based Linux distributions (Ubuntu, Linux Mint, etc.) you can download `.deb` package in the assets and run the command in terminal:
 
     ```sh
-    sudo apt install ./<path to .deb package>
+    sudo apt install <path to .deb package>
     ```
 
 Then type your root password and agree with the installation. You can also use `Gdebi` or another graphical tools to install `deb` package. Supported: Debian 10 Buster, Ubuntu 18.04 Bionic Beaver, Linux Mint 19 Tara and newer versions of these distributions or based on them.

--- a/content/en/docs/Installation/Install from binaries/_index.md
+++ b/content/en/docs/Installation/Install from binaries/_index.md
@@ -26,9 +26,10 @@ Download the `portable.zip` in the assets and unzip it to any directory you like
 Download the `AppImage` in the assets, add execute permission to it (`chmod +x <AppImagePath>`), then run it.
 
 On Debian-based Linux distributions (Ubuntu, Linux Mint and etc.) you can download `.deb` package in the assets and run the command in terminal:
-```sh
-sudo apt install ./<path to .deb package>
-```
+
+    ```sh
+    sudo apt install ./<path to .deb package>
+    ```
 Then type your root password and agree with the installation. You can also use `Gdebi` or another graphical tools to install `deb` package. Supported: Debian 10 Buster, Ubuntu 18.04 Bionic Beaver, Linux Mint 19 Tara and newer versions of these distributions or based on them.
 
 ### MacOS

--- a/content/en/docs/Installation/Install from binaries/_index.md
+++ b/content/en/docs/Installation/Install from binaries/_index.md
@@ -25,7 +25,7 @@ Download the `portable.zip` in the assets and unzip it to any directory you like
 
 Download the `AppImage` in the assets, add execute permission to it (`chmod +x <AppImagePath>`), then run it.
 
-On Debian-based Linux distributions (Ubuntu, Linux Mint and etc.) you can download `.deb` package in the assets and run the command in terminal:
+On Debian-based Linux distributions (Ubuntu, Linux Mint, etc.) you can download `.deb` package in the assets and run the command in terminal:
 
     ```sh
     sudo apt install ./<path to .deb package>


### PR DESCRIPTION
Update installation guide for deb releases
Feat: Add .deb release to pipeline [#568](https://github.com/cpeditor/cpeditor/pull/568), docs: update installation guide [#573](https://github.com/cpeditor/cpeditor/pull/573)