### PR TITLE
build: use scripts to auto build multiple versions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -22,13 +22,11 @@ jobs:
           hugo-version: "0.69.2"
           extended: true
       - name: Build Site
-        run: |
-          git config --global core.quotePath false
-          HUGO_ENV=production hugo --minify
+        run: HUGO_ENV=production ./build.sh
       - name: Check links
         id: check-links
         uses: peter-evans/link-checker@v1
         with:
-          args: -r public -d public -x "https?:\/\/"
+          args: -r dist -d dist -x "https?:\/\/"
       - name: Fail on link errors
         run: exit ${{ steps.check-links.outputs.exit_code }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,35 +3,33 @@ name: "Deploy"
 on:
   push:
     branches:
-    - hugo
+      - hugo
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Fetch submodules
-      run: git submodule update --init --recursive
-    - name: Setup Node
-      uses: actions/setup-node@v1
-      with:
-        node-version: '13.x'
-    - run: npm install
-    - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v2
-      with:
-        hugo-version: '0.69.2'
-        extended: true
-    - name: Build Site
-      run: |
-        git config --global core.quotePath false
-        HUGO_ENV=production hugo --minify
-    - name: Deploy
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        personal_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./public
-        publish_branch: master
-        commit_message: ${{ github.event.head_commit.message }}
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Fetch submodules
+        run: git submodule update --init --recursive
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: "13.x"
+      - run: npm install
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: "0.69.2"
+          extended: true
+      - name: Build Site
+        run: HUGO_ENV=production ./build.sh
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          personal_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          publish_branch: master
+          commit_message: ${{ github.event.head_commit.message }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - hugo
+      - "v*.*"
 
 jobs:
   deploy:
@@ -11,6 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          ref: hugo
           fetch-depth: 0
       - name: Fetch submodules
         run: git submodule update --init --recursive

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ public/
 resources/
 node_modules/
 tech-doc-hugo
+dist/

--- a/build.sh
+++ b/build.sh
@@ -28,12 +28,12 @@ function build() {
     git reset --hard
 }
 
-git switch hugo
+git checkout hugo
 build
 rm -rf dist; mv public dist
 
 for branch in $version_branches; do
-    git switch "$branch"
+    git checkout "$branch"
     git submodule update
     build "$branch"
     mv public "dist/$branch"

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ function build() {
     sed -i "s/baseURL = \"\/\"/baseURL = \"\/$1\"/" config.toml
 
     if [[ "$1" != "" ]]; then
-        sed -i "s/version = \".*\"/version = \"$1\"/" config.toml
+        sed -i "s/^version = \".*\"/version = \"$1\"/" config.toml
     fi
 
     echo "[[params.versions]]

--- a/build.sh
+++ b/build.sh
@@ -31,6 +31,6 @@ rm -rf dist; mv public dist
 for branch in $version_branches; do
     git switch "$branch"
     git submodule update
-    build $branch
+    build "$branch"
     mv public "dist/$branch"
 done

--- a/build.sh
+++ b/build.sh
@@ -25,9 +25,8 @@ function build() {
 }
 
 git switch hugo
-rm -rf dist; mkdir -p dist
 build
-mv public/* dist
+rm -rf dist; mv public dist
 
 for branch in $version_branches; do
     git switch "$branch"

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -e
+
+git config core.quotePath false
+
+version_branches="$(git for-each-ref --format='%(refname:short)' refs/heads/v*.*)"
+
+function build() {
+    sed -i "s/baseURL = \"\/\"/baseURL = \"\/$1\"/" config.toml
+
+    echo "[[params.versions]]
+    version = \"master\"
+    url = \"/\"" >> config.toml
+
+    for version in $version_branches; do
+        echo "[[params.versions]]
+        version = \"$version\"
+        url = \"/$version\"" >> config.toml
+    done
+
+    hugo --minify
+
+    git reset --hard
+}
+
+git switch hugo
+rm -rf dist; mkdir -p dist
+build
+mv public/* dist
+
+for branch in $version_branches; do
+    git switch "$branch"
+    git submodule update
+    build $branch
+    mv public "dist/$branch"
+done

--- a/build.sh
+++ b/build.sh
@@ -9,8 +9,12 @@ version_branches="$(git for-each-ref --format='%(refname:short)' refs/heads/v*.*
 function build() {
     sed -i "s/baseURL = \"\/\"/baseURL = \"\/$1\"/" config.toml
 
+    if [[ "$1" != "" ]]; then
+        sed -i "s/version = \".*\"/version = \"$1\"/" config.toml
+    fi
+
     echo "[[params.versions]]
-    version = \"master\"
+    version = \"alpha\"
     url = \"/\"" >> config.toml
 
     for version in $version_branches; do

--- a/config.toml
+++ b/config.toml
@@ -100,7 +100,7 @@ version = "alpha"
 
 # A link to latest version of the docs. Used in the "version-banner" partial to
 # point people to the main doc site.
-url_latest_version = "/"
+url_latest_version = "https://cpeditor.org"
 
 # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
 github_repo = "https://github.com/cpeditor/cpeditor.github.io"

--- a/config.toml
+++ b/config.toml
@@ -100,7 +100,7 @@ version = "alpha"
 
 # A link to latest version of the docs. Used in the "version-banner" partial to
 # point people to the main doc site.
-url_latest_version = "https://cpeditor.org"
+url_latest_version = "/"
 
 # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
 github_repo = "https://github.com/cpeditor/cpeditor.github.io"

--- a/config.toml
+++ b/config.toml
@@ -62,19 +62,19 @@ anonymizeIP = true
 [languages.en]
 title = "CP Editor"
 description = "The IDE for competitive programming"
-languageName ="English"
+languageName = "English"
 # Weight used for sorting.
 weight = 1
 [languages.zh]
 title = "CP Editor"
 description = "专为算法竞赛设计的 IDE"
-languageName ="中文"
+languageName = "中文"
 contentDir = "content/zh"
 
 [markup]
-  [markup.goldmark]
-    [markup.goldmark.renderer]
-      unsafe = true
+[markup.goldmark]
+[markup.goldmark.renderer]
+unsafe = true
 
 # Everything below this are Site Params
 
@@ -96,11 +96,11 @@ archived_version = false
 # The version number for the version of the docs represented in this doc set.
 # Used in the "version-banner" partial to display a version number for the 
 # current doc set.
-version = "0.0"
+version = "master"
 
 # A link to latest version of the docs. Used in the "version-banner" partial to
 # point people to the main doc site.
-url_latest_version = "https://github.com/cpeditor/cpeditor/releases/latest"
+url_latest_version = "/"
 
 # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
 github_repo = "https://github.com/cpeditor/cpeditor.github.io"
@@ -152,23 +152,23 @@ enable = false
 [params.links]
 # End user relevant links. These will show up on left side of footer and in the community page if you have one.
 [[params.links.user]]
-	name = "Telegram"
-	url = "https://t.me/cpeditor"
-	icon = "fab fa-telegram"
-        desc = "Get help on Telegram"
+name = "Telegram"
+url = "https://t.me/cpeditor"
+icon = "fab fa-telegram"
+desc = "Get help on Telegram"
 [[params.links.user]]
-	name ="QQ Group"
-	url = "https://jq.qq.com/?_wv=1027&k=50eq8yF"
-	icon = "fab fa-qq"
-        desc = "QQ group for Chinese users"
+name = "QQ Group"
+url = "https://jq.qq.com/?_wv=1027&k=50eq8yF"
+icon = "fab fa-qq"
+desc = "QQ group for Chinese users"
 # Developer relevant links. These will show up on right side of footer and in the community page if you have one.
 [[params.links.developer]]
-	name = "GitHub"
-	url = "https://github.com/cpeditor/cpeditor"
-	icon = "fab fa-github"
-        desc = "Development takes place here!"
+name = "GitHub"
+url = "https://github.com/cpeditor/cpeditor"
+icon = "fab fa-github"
+desc = "Development takes place here!"
 [[params.links.developer]]
-	name = "Slack"
-	url = "https://join.slack.com/t/cpeditor/shared_invite/zt-ekfy0zb5-SrOi8SIox8oq61oRonBynw"
-	icon = "fab fa-slack"
-        desc = "Chat with other project developers"
+name = "Slack"
+url = "https://join.slack.com/t/cpeditor/shared_invite/zt-ekfy0zb5-SrOi8SIox8oq61oRonBynw"
+icon = "fab fa-slack"
+desc = "Chat with other project developers"

--- a/config.toml
+++ b/config.toml
@@ -96,7 +96,7 @@ archived_version = false
 # The version number for the version of the docs represented in this doc set.
 # Used in the "version-banner" partial to display a version number for the 
 # current doc set.
-version = "master"
+version = "alpha"
 
 # A link to latest version of the docs. Used in the "version-banner" partial to
 # point people to the main doc site.


### PR DESCRIPTION
In the future, we can put documentation for different versions in different branches.

To preview, you can create branches like "v6.6" and "v6.7" at local and run the script. You can use programs like [http-server](https://www.npmjs.com/package/http-server) to view it on a local server.