### PR TITLE
fix(build-from-source): update stale doc

### DIFF
--- a/content/en/docs/Installation/Build from source/_index.md
+++ b/content/en/docs/Installation/Build from source/_index.md
@@ -12,12 +12,12 @@ description: In this way, you can get the latest unreleased features and get rea
     cd cpeditor
     ```
 
-2.  Install [Qt](https://www.qt.io/download) (5.14 or higher), [CMake](https://cmake.org/download/) (3.12 or higher) and [Python3](https://www.python.org/downloads/).
+2.  Install [Qt](https://www.qt.io/download) (5.15 or higher), [CMake](https://cmake.org/download/) (3.12 or higher) and [Python3](https://www.python.org/downloads/).
     -   On some Linux distributions and MacOS, you can install from your package manager. For example, `sudo pacman -S qt5` on Arch Linux, `brew install qt5` on Mac OS.
     -   You can also download the [offline installer](https://www.qt.io/offline-installers), or download from the [mirrors](https://download.qt.io/static/mirrorlist/). The path from the root of the mirror should be like `/qt/official_releases/qt/5.14/5.14.2/qt-opensource-<platform>-5.14.2.<suffix>` (or other versions).
     -   You can also use [aqtinstall](https://github.com/miurahr/aqtinstall) to install Qt.
 
-3.  If CMake can't find the Qt installation path, you should set environment variable: `CMAKE_PREFIX_PATH=%QtPath%/%QtVersion%/%Compiler%/lib/cmake`. For example, on Mac, you can run something like `export CMAKE_PREFIX_PATH="/usr/local/Cellar/qt/5.14.2"`.
+3.  If CMake can't find the Qt installation path, you should set environment variable: `CMAKE_PREFIX_PATH=%QtPath%/%QtVersion%/%Compiler%/lib/cmake`. For example, on Mac, you can run something like `export CMAKE_PREFIX_PATH="/usr/local/Cellar/qt/5.15.0"`.
 
 4.  Run the following commands:
 


### PR DESCRIPTION
Page [build-from-source](https://cpeditor.org/docs/installation/build-from-source/) seems stale now.

Now Qt 5.15 version is required.