### PR TITLE
chore: rename fix-md-format to lint and remove check-md-format

### DIFF
--- a/.github/workflows/remark-lint.yml
+++ b/.github/workflows/remark-lint.yml
@@ -12,8 +12,7 @@ jobs:
       with:
         node-version: '13.x'
     - run: npm install
-    - name: Run lint
-      run: npm run fix-md-format
+    - run: npm run lint
     - name: Check diff
       run: git diff --exit-code ${{ github.sha }}
     - name: Create Pull Request

--- a/package.json
+++ b/package.json
@@ -2,9 +2,7 @@
   "name": "cpeditor.github.io",
   "description": "The official website of CP Editor",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "fix-md-format": "remark content -o",
-    "check-md-format": "remark content -f"
+    "lint": "remark content -o"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
check-md-format is not useful, "fix-md-format" is too long. The conventional name for this is "lint".