### PR TITLE
fix(build-from-source): there's no offline installer for Qt 5.15+

### DIFF
--- a/content/docs/installation/build-from-source/_index.md
+++ b/content/docs/installation/build-from-source/_index.md
@@ -14,7 +14,6 @@ description: In this way, you can get the latest unreleased features and get rea
 
 2.  Install [Qt](https://www.qt.io/download) (5.15 or higher), [CMake](https://cmake.org/download/) (3.12 or higher) and [Python3](https://www.python.org/downloads/).
     -   On some Linux distributions and macOS, you can install from your package manager. For example, `sudo pacman -S qt5` on Arch Linux, `brew install qt5` on macOS.
-    -   You can also download the [offline installer](https://www.qt.io/offline-installers), or download from the [mirrors](https://download.qt.io/static/mirrorlist/). The path from the root of the mirror should be like `/qt/official_releases/qt/5.15/5.15.1/qt-opensource-<platform>-5.15.1.<suffix>` (or other versions).
     -   You can also use [aqtinstall](https://github.com/miurahr/aqtinstall) to install Qt.
 
 3.  If CMake can't find the Qt installation path, you should set environment variable: `CMAKE_PREFIX_PATH=%QtPath%/%QtVersion%/%Compiler%/lib/cmake`. For example, on macOS, you can run something like `export CMAKE_PREFIX_PATH="/usr/local/Cellar/qt/5.15.1"`.

--- a/content/docs/installation/build-from-source/_index.ru.md
+++ b/content/docs/installation/build-from-source/_index.ru.md
@@ -14,7 +14,6 @@ description: In this way, you can get the latest unreleased features and get rea
 
 2.  Install [Qt](https://www.qt.io/download) (5.15 or higher), [CMake](https://cmake.org/download/) (3.12 or higher) and [Python3](https://www.python.org/downloads/).
     -   On some Linux distributions and macOS, you can install from your package manager. For example, `sudo pacman -S qt5` on Arch Linux, `brew install qt5` on macOS.
-    -   You can also download the [offline installer](https://www.qt.io/offline-installers), or download from the [mirrors](https://download.qt.io/static/mirrorlist/). The path from the root of the mirror should be like `/qt/official_releases/qt/5.15/5.15.1/qt-opensource-<platform>-5.15.1.<suffix>` (or other versions).
     -   You can also use [aqtinstall](https://github.com/miurahr/aqtinstall) to install Qt.
 
 3.  If CMake can't find the Qt installation path, you should set environment variable: `CMAKE_PREFIX_PATH=%QtPath%/%QtVersion%/%Compiler%/lib/cmake`. For example, on macOS, you can run something like `export CMAKE_PREFIX_PATH="/usr/local/Cellar/qt/5.15.1"`.


### PR DESCRIPTION
This was updated in https://github.com/cpeditor/cpeditor/pull/378, but the English version hasn't been addressed here.