### PR TITLE
fix: disable Google Analytics

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,6 +7,8 @@ git config core.quotePath false
 version_branches="$(git for-each-ref --format='%(refname:lstrip=3)' refs/remotes/*/v*.* | sort -Vur)"
 
 function build() {
+    sed -i 's/^id = "UA-/# id = "UA-/' config.toml # disable GA
+
     if [[ "$1" != "" ]]; then
         sed -i "s/^version = \".*\"/version = \"$1\"/" config.toml
         sed -i "s/^github_branch = \".*\"/github_branch = \"$1\"/" config.toml

--- a/config.toml
+++ b/config.toml
@@ -47,14 +47,9 @@ anchor = "smart"
 [minify]
 disableHTML = true
 
-[services]
-[services.googleAnalytics]
-# Comment out the next line to disable GA tracking. Also disables the feature described in [params.ui.feedback].
-id = "UA-96337051-5"
-
 [privacy]
 [privacy.googleAnalytics]
-disabled = false
+disabled = true
 respectDoNotTrack = true
 anonymizeIP = true
 useSessionStorage = true

--- a/content/download/_index.html
+++ b/content/download/_index.html
@@ -23,8 +23,7 @@ menu:
                 <h1>Get CP Editor on your machine and have a try!</h1>
                 <p v-if="latestStableAssetForUserPlatform" class="pt-3">
                     You probably want to use
-                    <a class="text-light" :href="latestStableAssetForUserPlatform.browser_download_url"
-                       v-on:click="latestStableEvent">
+                    <a class="text-light" :href="latestStableAssetForUserPlatform.browser_download_url">
                         the latest stable version on {{ userPlatform }}
                     </a>.
                 </p>
@@ -78,7 +77,7 @@ menu:
                     <a :href="selectedAsset.browser_download_url"
                         :disabled="selectedAsset.browser_download_url === undefined"
                         class="btn btn-primary btn-block my-4"
-                        v-on:click="downloadEvent">Download</a>
+                    >Download</a>
                 </template>
             </div>
         </div>

--- a/static/js/download.js
+++ b/static/js/download.js
@@ -55,16 +55,6 @@ function getOS() {
     return "Linux";
   }
 
-  if (typeof ga === "function") {
-    ga(
-      "send",
-      "event",
-      "Unknown Platform",
-      window.navigator.platform,
-      window.navigator.userAgent
-    );
-  }
-
   return null;
 }
 
@@ -125,29 +115,6 @@ $(document).ready(() => {
             this.selectedPlatform
           );
         }
-      },
-      latestStableEvent() {
-        this.sendGAEvent(
-          "latest-stable-link",
-          this.latestStableAssetForUserPlatform
-        );
-      },
-      downloadEvent() {
-        if (typeof ga !== "function") return;
-        this.sendGAEvent("download-button", this.selectedAsset);
-        if (this.selectedPlatform !== this.userPlatform) {
-          ga(
-            "send",
-            "event",
-            "Download for another platform",
-            `download-for-${this.selectedPlatform}-on-${this.userPlatform}`,
-            `userAgent: ${window.navigator.userAgent}; platform: ${window.navigator.platform}; asset: ${this.selectedAsset.name}`
-          );
-        }
-      },
-      sendGAEvent(action, asset) {
-        if (typeof ga !== "function") return;
-        ga("send", "event", "Download", action, asset.name);
       },
     },
     computed: {


### PR DESCRIPTION
> Google Analytics Now Illegal in Austria; Other EU Member States Expected to Follow

We can use alternatives such as Matomo. But since we don't actually use the statistics to improve user experiences very often, we can simply drop it.

refs:
- https://matomo.org/blog/2022/01/google-analytics-gdpr-violation/
- https://noyb.eu/en/austrian-dsb-eu-us-data-transfers-google-analytics-illegal