### PR TITLE
fix(download): make download page functional without Vue loaded

### DIFF
--- a/content/download/_index.html
+++ b/content/download/_index.html
@@ -16,12 +16,12 @@ menu:
     }
 </style>
 
-<div id="app" v-cloak>
+<div id="app">
     <section class="row td-box td-box--1 position-relative td-box--gradient td-box--height-auto">
         <div class="container text-center td-arrow-down">
             <span class="h4 mb-0">
                 <h1>Get CP Editor on your machine and have a try!</h1>
-                <p v-if="latestStableAssetForUserPlatform" class="pt-3">
+                <p v-cloak v-if="latestStableAssetForUserPlatform" class="pt-3">
                     You probably want to use
                     <a class="text-light" :href="latestStableAssetForUserPlatform.browser_download_url">
                         the latest stable version on {{ userPlatform }}
@@ -34,7 +34,7 @@ menu:
     <div class="container pt-5">
         <div class="row">
             <div class="col-lg-6 text-center">
-                <h2>Choose your platform and the version you want to download</h2>
+                <h2 v-cloak>Choose your platform and the version you want to download</h2>
                 <ul class="list-group pt-2">
                     <li class="list-group-item"><a href="../docs/installation">Installation instructions</a></li>
                     <li class="list-group-item">
@@ -42,7 +42,7 @@ menu:
                     </li>
                 </ul>
             </div>
-            <div class="col-lg-6">
+            <div v-cloak class="col-lg-6">
                 <h2 v-if="releases.length === 0">Loading...</h2>
                 <h2 v-else-if="!selectedAsset" class="text-warning">No available asset found</h2>
                 <template v-else>

--- a/content/download/_index.ru.html
+++ b/content/download/_index.ru.html
@@ -16,12 +16,12 @@ menu:
     }
 </style>
 
-<div id="app" v-cloak>
+<div id="app">
     <section class="row td-box td-box--1 position-relative td-box--gradient td-box--height-auto">
         <div class="container text-center td-arrow-down">
             <span class="h4 mb-0">
                 <h1>Установи и попробуй CP Editor!</h1>
-                <p v-if="latestStableAssetForUserPlatform" class="pt-3">
+                <p v-cloak v-if="latestStableAssetForUserPlatform" class="pt-3">
                     Скорее всего вам нужна
                     <a class="text-light" :href="latestStableAssetForUserPlatform.browser_download_url">
                         последняя стабильная версия для {{ userPlatform }}
@@ -34,7 +34,7 @@ menu:
     <div class="container pt-5">
         <div class="row">
             <div class="col-lg-6 text-center">
-		<h2>Выберите платформу и версию, которую вы хотите скачать</h2>
+                <h2 v-cloak>Выберите платформу и версию, которую вы хотите скачать</h2>
                 <ul class="list-group pt-2">
                     <li class="list-group-item"><a href="../docs/installation">Инструкции для установки</a></li>
                     <li class="list-group-item">
@@ -42,7 +42,7 @@ menu:
                     </li>
                 </ul>
             </div>
-            <div class="col-lg-6">
+            <div v-cloak class="col-lg-6">
                 <h2 v-if="releases.length === 0">Загрузка...</h2>
                 <h2 v-else-if="!selectedAsset" class="text-warning">Необходимый файл не найден</h2>
                 <template v-else>

--- a/content/download/_index.zh.html
+++ b/content/download/_index.zh.html
@@ -6,8 +6,8 @@ menu:
     weight: 50
 ---
 
-<script src="https://cdn.jsdelivr.net/npm/vue@2.6/dist/vue.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/filesize@6.4"></script>
+<script src="https://cdn.bootcdn.net/ajax/libs/vue/2.6.14/vue.min.js"></script>
+<script src="https://cdn.bootcdn.net/ajax/libs/filesize/6.4.0/filesize.min.js"></script>
 <script src="/js/download.js"></script>
 
 <style>

--- a/content/download/_index.zh.html
+++ b/content/download/_index.zh.html
@@ -16,12 +16,12 @@ menu:
     }
 </style>
 
-<div id="app" v-cloak>
+<div id="app">
     <section class="row td-box td-box--1 position-relative td-box--gradient td-box--height-auto">
         <div class="container text-center td-arrow-down">
             <span class="h4 mb-0">
                 <h1>在你的计算机上获取 CP Editor，然后试一试！</h1>
-                <p v-if="latestStableAssetForUserPlatform" class="pt-3">
+                <p v-cloak v-if="latestStableAssetForUserPlatform" class="pt-3">
                     你可能想要使用
                     <a class="text-light" :href="latestStableAssetForUserPlatform.browser_download_url">
                         在 {{ userPlatform }} 上的最新稳定版本
@@ -34,7 +34,7 @@ menu:
     <div class="container pt-5">
         <div class="row">
             <div class="col-lg-6 text-center">
-                <h2>选择你使用的平台和想要下载的版本</h2>
+                <h2 v-cloak>选择你使用的平台和想要下载的版本</h2>
                 <ul class="list-group pt-2">
                     <li class="list-group-item"><a href="../docs/installation">安装说明</a></li>
                     <li class="list-group-item">
@@ -48,7 +48,7 @@ menu:
                     </li>
                 </ul>
             </div>
-            <div class="col-lg-6">
+            <div v-cloak class="col-lg-6">
                 <h2 v-if="releases.length === 0">加载中...</h2>
                 <h2 v-else-if="!selectedAsset" class="text-warning">找不到可下载的文件</h2>
                 <template v-else>

--- a/content/download/_index.zh_tw.html
+++ b/content/download/_index.zh_tw.html
@@ -16,12 +16,12 @@ menu:
     }
 </style>
 
-<div id="app" v-cloak>
+<div id="app">
     <section class="row td-box td-box--1 position-relative td-box--gradient td-box--height-auto">
         <div class="container text-center td-arrow-down">
             <span class="h4 mb-0">
                 <h1>立即安裝並體驗 CP Editor</h1>
-                <p v-if="latestStableAssetForUserPlatform" class="pt-3">
+                <p v-cloak v-if="latestStableAssetForUserPlatform" class="pt-3">
                     您可能想找適用於
                     <a class="text-light" :href="latestStableAssetForUserPlatform.browser_download_url">
                          {{ userPlatform }} 系統的最新穩定版
@@ -34,7 +34,7 @@ menu:
     <div class="container pt-5">
         <div class="row">
             <div class="col-lg-6 text-center">
-                <h2>選擇您的作業系統及想要下載的版本</h2>
+                <h2 v-cloak>選擇您的作業系統及想要下載的版本</h2>
                 <ul class="list-group pt-2">
                     <li class="list-group-item"><a href="../docs/installation">安裝說明</a></li>
                     <li class="list-group-item">
@@ -42,7 +42,7 @@ menu:
                     </li>
                 </ul>
             </div>
-            <div class="col-lg-6">
+            <div v-cloak class="col-lg-6">
                 <h2 v-if="releases.length === 0">載入中...</h2>
                 <h2 v-else-if="!selectedAsset" class="text-warning">未取得可用的檔案清單</h2>
                 <template v-else>


### PR DESCRIPTION
Recently jsDelivr is not very reachable in mainland China.

We may use other CDNs, but:

1.  A CDN reachable in China may be slow in other regions.
2.  If a user cannot reach jsDelivr, it's very likely that they also cannot reach GitHub or the connection would be very slow, which may make the version list not very helpful.
3.  Maybe the new CDN will be unavailable in the future.

So the solution in this commit is to put fewer elements in v-cloak so that the link to the Releases page and links to the mirrors are available without Vue being loaded.