### PR TITLE
fix(ru/docs/faq): add translated frontmatter

### DIFF
--- a/content/docs/faq/_index.ru.md
+++ b/content/docs/faq/_index.ru.md
@@ -1,6 +1,7 @@
 ---
 title: "FAQ"
 linkTitle: "FAQ"
+translated: true
 weight: 70
 description: Вопросы, которые часто задают пользователи CP Editor
 ---


### PR DESCRIPTION
The translated frontmatter should be set when the page title cannot be translated.