### PR TITLE
Updated documentation after adding options for error/warning message colors

### DIFF
--- a/content/docs/preferences/appearance/_index.md
+++ b/content/docs/preferences/appearance/_index.md
@@ -27,6 +27,10 @@ The syntax highlighting theme for the code editor.
 
 The opacity of the main window.
 
+### Message Color
+
+The text color of the displayed warning messages and error messages.
+
 ### Test Case Maximum Height
 
 The maximum height of a test case before the scrollbar occurs.


### PR DESCRIPTION
Updated documentation after adding options for error/warning message colors.

## Description

Added in "content/docs/preferences/appearance/_index.md" the info about the recently added feature that allows the user to change the text color of the warning/error messages.

## Related

The feature PR (in "cpeditor" repository) can be acessed by this [link](https://github.com/cpeditor/cpeditor/pull/1247).