### PR TITLE
Bump CI to Node 26 and Hugo 0.161.1

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -14,13 +14,13 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: "16.x"
+          node-version: "26.x"
           cache: 'yarn'
       - run: yarn
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: "0.147.0"
+          hugo-version: "0.161.1"
           extended: true
       - name: Build Site
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,13 +17,13 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: "16.x"
+          node-version: "26.x"
           cache: 'yarn'
       - run: yarn
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: "0.147.0"
+          hugo-version: "0.161.1"
           extended: true
       - name: Build Site
         run: HUGO_ENV=production ./build.sh


### PR DESCRIPTION
Updates CI workflows to use:

- Node 26.x (from 16.x)
- Hugo 0.161.1 extended (from 0.147.0)