### PR TITLE
Fix CI deploy: disable RSS and fix deprecated config

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -24,7 +24,7 @@ function build() {
         url = \"https://cpeditor.org/$version\"" >>config.toml
     done
 
-    hugo --minify
+    hugo --minify --disableKinds=RSS
 
     if [[ "$1" != "" ]]; then
         rm public/CNAME public/robots.txt

--- a/config.toml
+++ b/config.toml
@@ -59,22 +59,22 @@ useSessionStorage = true
 [languages.en]
 title = "CP Editor"
 description = "The IDE for competitive programming"
-languageName = "English"
+label = "English"
 weight = 1
 [languages.ru]
 title = "CP Editor"
 description = "редактор, созданный для спортивного программирования"
-languageName = "Русский"
+label = "Русский"
 weight = 2
 [languages.zh]
 title = "CP Editor"
 description = "专为算法竞赛设计的 IDE"
-languageName = "简体中文"
+label = "简体中文"
 weight = 3
 [languages.zh_tw]
 title = "CP Editor"
 description = "專為競程設計的 IDE"
-languageName = "正體中文"
+label = "正體中文"
 weight = 4
 
 [markup]


### PR DESCRIPTION
Two fixes:

1. **build.sh** — Added `--disableKinds=RSS` to Hugo command. Version branches (v6.11, v7.0, etc.) use the old Docsy theme whose RSS template fails with Hugo 0.161+.

2. **config.toml** — Changed `languageName` to `label` (deprecated since Hugo 0.158).